### PR TITLE
Change hash printing from hex to string

### DIFF
--- a/explorer.go
+++ b/explorer.go
@@ -84,7 +84,7 @@ func (es *ExploreServer) heightHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	http.Redirect(w, r, fmt.Sprintf("hash?h=%x", blockSummaries[0].ID), 301)
+	http.Redirect(w, r, fmt.Sprintf("hash?h=%s", blockSummaries[0].ID), 301)
 }
 
 // rootHandler handles the root page being requested. Is responsible for

--- a/template.go
+++ b/template.go
@@ -119,6 +119,7 @@ func (es *ExploreServer) parseTemplate(templateName string, data interface{}) ([
 		"increment":        func(x types.BlockHeight) types.BlockHeight { return x + 1 },
 		"uint64":           func(x int) uint64 { return uint64(x) },
 		"int64_uint64":     func(x int64) uint64 { return uint64(x) },
+		"txidToHash":       func(x types.TransactionID) crypto.Hash { return crypto.Hash(x) },
 	}
 
 	t, err := template.New(templateName).Funcs(funcMap).ParseFiles("templates/" + templateName)

--- a/templates/address.html
+++ b/templates/address.html
@@ -1,5 +1,5 @@
 {{printf "Address %x" .Addr |  parseTemplate "header.template" | printf "%s"}}
 {{range .Txns}}
-{{parseTransaction . | printf "%s"}}
+{{txidToHash . | parseTransaction | printf "%s"}}
 {{end}}
 {{printf "Address %x" .Addr |  parseTemplate "footer.template" | printf "%s"}}

--- a/templates/block.template
+++ b/templates/block.template
@@ -3,11 +3,11 @@
     <table>
       <tr>
 	<td>Block ID</td>
-	<td>{{printf "%x" .Block.ID}}</td>
+	<td>{{printf "%s" .Block.ID}}</td>
       </tr>
       <tr>
 	<td>Block Parent ID</td>
-	<td><a href='hash?h={{printf "%x" .Block.ParentID}}'>{{printf "%x" .Block.ParentID}}</a></td>
+	<td><a href='hash?h={{printf "%s" .Block.ParentID}}'>{{printf "%s" .Block.ParentID}}</a></td>
       </tr>
       <tr>
 	<td>Child</td>
@@ -34,7 +34,7 @@
 	<td>
 	  <ul>
 	    {{range .Block.Transactions}}
-	    <li><a href='hash?h={{printf "%x" .ID}}'>{{printf "%x" .ID}}</a></li>
+	    <li><a href='hash?h={{printf "%s" .ID}}'>{{printf "%s" .ID}}</a></li>
 	    {{end}}
 	  </ul>
 	</td>
@@ -51,8 +51,8 @@
 	    {{range $index, $element := .Block.MinerPayouts}}
 	    <tr>
 	      <td>
-		<a href='hash?h={{$index | uint64 | $root.Block.MinerPayoutID | printf "%x"}}'>
-		  {{$index | uint64 | $root.Block.MinerPayoutID | printf "%x"}}
+		<a href='hash?h={{$index | uint64 | $root.Block.MinerPayoutID | printf "%s"}}'>
+		  {{$index | uint64 | $root.Block.MinerPayoutID | printf "%s"}}
 		</a>
 	      </td>
 	      <td>{{siacoinString $element.Value}}</td>

--- a/templates/output.html
+++ b/templates/output.html
@@ -1,4 +1,4 @@
 {{printf "Output ID %x" .OutputID |  parseTemplate "header.template" | printf "%s"}}
-{{parseTransaction .OutputTx | printf "%s"}}
-{{parseTransaction .InputTx | printf "%s"}}
+{{txidToHash .OutputTx | parseTransaction | printf "%s"}}
+{{txidToHash .InputTx | parseTransaction | printf "%s"}}
 {{printf "Output ID %x" .OutputID |  parseTemplate "footer.template" | printf "%s"}}

--- a/templates/transaction.html
+++ b/templates/transaction.html
@@ -1,3 +1,3 @@
-{{printf "Transaction %x" .Tx.ID |  parseTemplate "header.template" | printf "%s"}}
+{{printf "Transaction %s" .Tx.ID |  parseTemplate "header.template" | printf "%s"}}
 {{parseTemplate "transaction.template" . | printf "%s"}}
-{{printf "Transaction %x" .Tx.ID |  parseTemplate "footer.template" | printf "%s"}}
+{{printf "Transaction %s" .Tx.ID |  parseTemplate "footer.template" | printf "%s"}}

--- a/templates/transaction.template
+++ b/templates/transaction.template
@@ -3,11 +3,11 @@
     <table>
       <tr>
 	<td>Transaction ID</td>
-	<td>{{printf "%x" .Tx.ID}}</td>
+	<td>{{printf "%s" .Tx.ID}}</td>
       </tr>
       <tr>
 	<td>Block ID</td>
-	<td><a href='hash?h={{printf "%x" .ParentID}}'>{{printf "%x" .ParentID}}</a></td>
+	<td><a href='hash?h={{printf "%s" .ParentID}}'>{{printf "%s" .ParentID}}</a></td>
       </tr>
       <tr>
 	<td>Siacoin Inputs</td>
@@ -21,7 +21,7 @@
 	    {{range .Tx.SiacoinInputs}}
 	    {{$output := findOutput .ParentID}}
 	    <tr>
-	      <td><a href='hash?h={{printf "%x" .ParentID}}'>{{printf "%x" .ParentID}}</a></td>
+	      <td><a href='hash?h={{printf "%s" .ParentID}}'>{{printf "%s" .ParentID}}</a></td>
 	      <td>{{siacoinString $output.Value}}</td>
 	      <td><a href='hash?h={{$output.UnlockHash.String}}'>{{$output.UnlockHash.String}}</a></td>
 	    {{end}}
@@ -40,8 +40,8 @@
 	    {{range $index, $element := .Tx.SiacoinOutputs}}
 	    <tr>
 	      <td>
-		<a href='hash?h={{$index | $root.Tx.SiacoinOutputID | printf "%x"}}'>
-		  {{$index | $root.Tx.SiacoinOutputID | printf "%x"}}
+		<a href='hash?h={{$index | $root.Tx.SiacoinOutputID | printf "%s"}}'>
+		  {{$index | $root.Tx.SiacoinOutputID | printf "%s"}}
 		</a>
 	      </td>
 	      <td>{{siacoinString $element.Value}}</td>
@@ -54,8 +54,8 @@
     </table>
     <h4>File Contracts</h4>
     {{range $index, $element := .Tx.FileContracts}}
-    <h5><a href='hash?h={{$index | $root.Tx.FileContractID | printf "%x"}}'>
-	{{$index | $root.Tx.FileContractID | printf "%x"}}
+    <h5><a href='hash?h={{$index | $root.Tx.FileContractID | printf "%s"}}'>
+	{{$index | $root.Tx.FileContractID | printf "%s"}}
     </a></h5>
     <table>
       <tr>
@@ -79,8 +79,8 @@
 	    {{$fcid := $root.Tx.FileContractID $FCindex}}
 	    <tr>
 	      <td>
-		<a href='hash?h={{$FCindex | uint64 | $fcid.StorageProofOutputID true | printf "%x"}}'>
-		  {{$FCindex | uint64 | $fcid.StorageProofOutputID true | printf "%x"}}
+		<a href='hash?h={{$FCindex | uint64 | $fcid.StorageProofOutputID true | printf "%s"}}'>
+		  {{$FCindex | uint64 | $fcid.StorageProofOutputID true | printf "%s"}}
 		</a>
 	      </td>
 	      <td>{{siacoinString $FCelement.Value}}</td>


### PR DESCRIPTION
Seems the way hashes are printed has changed in the types package, so things were getting double hashed.
